### PR TITLE
Add support for different project layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,4 @@ requires = ["setuptools", "setuptools-protobuf"]
 [tool.setuptools-protobuf]
 mypy = true
 protobufs = ["example/foo.proto"]
-# srcdir is used as the cwd for the protoc commands. Defaults to the project root if not specified.
-srcdir = "src"
 ```

--- a/README.md
+++ b/README.md
@@ -46,4 +46,6 @@ requires = ["setuptools", "setuptools-protobuf"]
 [tool.setuptools-protobuf]
 mypy = true
 protobufs = ["example/foo.proto"]
+# srcdir is used as the cwd for the protoc commands. Defaults to the project root if not specified.
+srcdir = "src"
 ```


### PR DESCRIPTION
My projects use the src-layout (defined here https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#src-layout) and are currently incompatible with this package. Without this change, this tool only works with a flat project layout. The Protobuf compiler runs from the project root which breaks the import pathing.

By adding the `srcdir` argument, the Protobuf compiler command can be run from the directory your packages exist in (in my case `src/') and the resulting autogenerated code will have the correct import paths.