### PR TITLE
Expand platform check values

### DIFF
--- a/setuptools_protobuf/__init__.py
+++ b/setuptools_protobuf/__init__.py
@@ -162,7 +162,7 @@ def get_protoc(version):
         return None
 
     # determine the release string including system and machine info of protoc
-    machine = platform.machine()
+    machine = platform.machine().lower()
     if machine in ['amd64', 'x64', 'x86_64']:
         machine = 'x86_64'
     elif machine in ['aarch64', 'arm64', 'aarch_64']:


### PR DESCRIPTION
Some machines, notably Windows, may return UPPERCASE platform machine strings.