### PR TITLE
Fix the package for setuptools

### DIFF
--- a/.github/workflows/exampletest.yml
+++ b/.github/workflows/exampletest.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Validate that example builds 
         run: |
           # --no-isolation, so that we use the version we've just built.
-          python -m build --no-isolation --example
+          python -m build --no-isolation example

--- a/.github/workflows/exampletest.yml
+++ b/.github/workflows/exampletest.yml
@@ -32,8 +32,7 @@ jobs:
           python -m pip install --upgrade setuptools build
       - name: Build and install the package
         run: |
-          python -m build
-          pip install dist/*.whl
+          python -m pip install .
       - name: Validate that example builds 
         run: |
           # --no-isolation, so that we use the version we've just built.

--- a/.github/workflows/exampletest.yml
+++ b/.github/workflows/exampletest.yml
@@ -1,0 +1,39 @@
+---
+name: Testing that the example builds.
+
+"on":
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 6 * * *"   # Daily 6AM UTC build
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version:
+          - '3.13'
+          - '3.12'
+          - '3.11'
+          - '3.10'
+          - '3.9'
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade setuptools
+      - name: Build and install the package
+        run: |
+          python -m build
+          pip install dist/*.whl
+      - name: Validate that example builds 
+        run: |
+          python -m build example

--- a/.github/workflows/exampletest.yml
+++ b/.github/workflows/exampletest.yml
@@ -29,11 +29,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade setuptools build
       - name: Build and install the package
         run: |
           python -m build
           pip install dist/*.whl
       - name: Validate that example builds 
         run: |
-          python -m build example
+          # --no-isolation, so that we use the version we've just built.
+          python -m build --no-isolation --example

--- a/example/pyproject.toml
+++ b/example/pyproject.toml
@@ -7,3 +7,4 @@ version = "0.0.1"
 
 [tool.setuptools-protobuf]
 protobufs = ["example/foo.proto"]
+protoc_version = "31.1"

--- a/setuptools_protobuf/__init__.py
+++ b/setuptools_protobuf/__init__.py
@@ -67,7 +67,7 @@ class build_protobuf(Command):
                 raise ExecError(f'error running protoc: {e.returncode}')
             self.outfiles.extend(protobuf.outputs())
 
-    def get_inputs(self) -> list[str]:
+    def get_source_files(self) -> list[str]:
         return [
             protobuf.path
             for protobuf in self.distribution.protobufs]  # type: ignore


### PR DESCRIPTION
See #58  for more context.

Rename `get_sources` to `get_source_files` and add a GitHub workflow to make sure there is no regression in buildability of the example.

Setuptools [build.SubCommand](https://github.com/pypa/setuptools/blob/c675d781f89f2057c8e5e0e53896adf468cfbac1/setuptools/command/build.py#L360) interface seems to only require get_source_files, and it does seem to require it in this case.